### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-gcc.yml
+++ b/.github/workflows/build-gcc.yml
@@ -6,6 +6,9 @@ on:
       - main
       - master 
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/artorg-unibe-ch/HFE/security/code-scanning/2](https://github.com/artorg-unibe-ch/HFE/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that scopes the `GITHUB_TOKEN` to the least privilege needed by this workflow. Since this job uses only Docker-related actions and Docker Hub credentials (via `secrets.DOCKERHUB_*`) and does not modify the repository, it likely needs at most read access to repository contents—and in many cases, no token permissions at all. The standard minimal pattern is `permissions: contents: read` at the workflow or job level.

The single best minimal-impact fix, without changing existing functionality, is to add a workflow-level `permissions` block right after the `on:` section (or before `jobs:`). This will apply to all jobs (here, just `docker`) and ensures `GITHUB_TOKEN` is limited even if future steps are added. A safe and common baseline is:
```yaml
permissions:
  contents: read
```
This preserves read access for any future step that might need to read repository contents via `GITHUB_TOKEN`, while removing write powers. Concretely, in `.github/workflows/build-gcc.yml`, add these two lines between the `on:` block (ending at line 7–8) and the `jobs:` key on line 9. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
