### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,5 +1,8 @@
 name: Run pytest
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/artorg-unibe-ch/HFE/security/code-scanning/4](https://github.com/artorg-unibe-ch/HFE/security/code-scanning/4)

In general, to fix this issue you should explicitly declare a `permissions:` block that grants only the minimum necessary scopes for the workflow, either at the root of the workflow (applying to all jobs) or within the specific job. This overrides potentially broad default token permissions and clearly documents what the workflow requires.

For this specific workflow, the `pytest` job only checks out code and runs tests; it does not need to write to the repository or interact with issues or PRs. The minimal safe permissions are `contents: read`, which is enough for `actions/checkout` to function. To avoid changing existing functionality, we will add a root-level `permissions:` block just after the `name:` line, setting `contents: read`. This will apply to all jobs (currently only `pytest`) and will not interfere with any of the existing steps, since none require write access.

Concretely:
- Edit `.github/workflows/pytest.yaml`.
- Insert a new root-level `permissions:` section after line 1 (`name: Run pytest`), with `contents: read`.
- No imports, methods, or additional definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
