### PR TITLE
Update validation comment for n_elms_radial in mesh.yaml

### DIFF
--- a/02_CODE/cfg/examples/mesh.yaml
+++ b/02_CODE/cfg/examples/mesh.yaml
@@ -26,7 +26,7 @@ meshing_settings:
   n_elms_longitudinal: 3              # validation: 3
   n_elms_transverse_trab: 13          # validation: 13
   n_elms_transverse_cort: 3           # validation: 3
-  n_elms_radial: 60                   # validation: 15; should be 40 if trab_refinement is True
+  n_elms_radial: 60                   # validation: 60; should be 40 if trab_refinement is True
   ellipsoid_fitting: True
 
   show_plots: False                   # show plots during construction


### PR DESCRIPTION
In previous revisions, `n_elms_radial` was set as a quarter of the circumference. Latest commits modified this to 4*`n_elms_radial` to make it more straightforward. No functionality was changed. The comment now reflects the `n_elms_radial` used for validation with this change.